### PR TITLE
Add in a CI to Ensure the Apptainer/Singularity Container is Buildable

### DIFF
--- a/.github/workflows/test_CondaEnv.yml
+++ b/.github/workflows/test_CondaEnv.yml
@@ -1,6 +1,9 @@
 name: 'Conda Env Verified (Ubuntu & MacOS)'
 
-on: [push]
+on: 
+  push:
+    paths:
+      - '*_env.yml'
 
 jobs:
   build-conda-env:

--- a/.github/workflows/test_Singularity.yml
+++ b/.github/workflows/test_Singularity.yml
@@ -20,4 +20,6 @@ jobs:
         with:
           apptainer-version: 1.1.3
       - name: Run an apptainer container
-        run: apptainer build containers/Singularity 
+        run: |
+          mkdir image-build
+          apptainer build image-build/ containers/Singularity 

--- a/.github/workflows/test_Singularity.yml
+++ b/.github/workflows/test_Singularity.yml
@@ -21,5 +21,4 @@ jobs:
           apptainer-version: 1.1.3
       - name: Run an apptainer container
         run: |
-          mkdir image-build
-          apptainer build image-build/ containers/Singularity 
+          apptainer build image-build containers/Singularity 

--- a/.github/workflows/test_Singularity.yml
+++ b/.github/workflows/test_Singularity.yml
@@ -1,0 +1,23 @@
+name: 'Singularity Build (Ubuntu)'
+
+on: [push]
+
+#on: 
+#  push:
+#    paths:
+#      - 'containers/Singularity'
+
+jobs:
+  build-conda-env:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      max-parallel: 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: eWaterCycle/setup-apptainer@v2.0.0
+        with:
+          apptainer-version: 1.1.3
+      - name: Run an apptainer container
+        run: apptainer build containers/Singularity 

--- a/.github/workflows/test_Singularity.yml
+++ b/.github/workflows/test_Singularity.yml
@@ -1,14 +1,15 @@
-name: 'Singularity Build (Ubuntu)'
+name: 'Apptainer Build (Ubuntu)'
 
-on: [push]
+#on: [push]
 
-#on: 
-#  push:
-#    paths:
-#      - 'containers/Singularity'
+on: 
+  push:
+    paths:
+      - 'containers/Singularity'
+      - '.github/workflows/*.yml'
 
 jobs:
-  build-conda-env:
+  build-apptainer-image:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Conda Env Test](https://github.com/IPTA/pulsar-env/actions/workflows/test_CondaEnv.yml/badge.svg)
+![Apptainer Build (Ubuntu)](https://github.com/IPTA/pulsar-env/actions/workflows/test_Singularity.yml/badge.svg)
 
 # Pulsar Timing Environments
 


### PR DESCRIPTION
Finalized building some CI Tests for the Apptainer (formerly Singularity) image to ensure any time it changes, it is built with the most recent version.

~ Joe G.